### PR TITLE
Fix handling of non-standard assay name by estimateStability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ReducedExperiment
 Type: Package
 Title: Containers and tools for dimensionally-reduced -omics representations
-Version: 0.99.5
+Version: 0.99.6
 Authors@R: c(
     person("Jack", "Gisby", , "jackgisby@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0511-8123")),

--- a/R/factors.R
+++ b/R/factors.R
@@ -551,11 +551,7 @@ estimateStability <- function(
     ...
 ) {
     if (inherits(X, "SummarizedExperiment")) {
-        X <- assay(X, "normal")
-    }
-
-    if (assay_name != "normal") {
-        assay(X, "normal") <- assay(X, assay_name)
+        X <- assay(X, assay_name)
     }
 
     if (dim(X)[2] < max_components) {

--- a/R/modules.R
+++ b/R/modules.R
@@ -73,6 +73,7 @@ identifyModules <- function(
     if ("transformed" %in% assayNames(X)) {
         warning("Overwriting 'transformed' assay slot in X")
     }
+
     assay(X, "transformed") <-
         t(scale(t(assay(X, "normal")), center = center_X, scale = scale_X))
 
@@ -203,10 +204,11 @@ assessSoftThreshold <- function(
     maxBlockSize = 30000, verbose = 0, ...
 ) {
     .maxBlockSizeCheck(maxBlockSize, nrow(X))
-    cor <- corFnc <- .getCorFn(cor_type) # Get correlation function
+    cor <- corFnc <- .getCorFn(cor_type)  # Get correlation function
 
-    if (inherits(X, "SummarizedExperiment"))
+    if (inherits(X, "SummarizedExperiment")){
         X <- assay(X, assay_name)
+    }
 
     args <- list(
         data = t(X),

--- a/tests/testthat/test_factors.R
+++ b/tests/testthat/test_factors.R
@@ -3,7 +3,8 @@ context("reduce_data")
 test_that("Estimate factors", {
     # Use real data from airway package
     airway <- .getAirwayData()
-    airway_fe <- estimateFactors(airway, nc = 2)
+    assayNames(airway) <- c("counts", "normalised")  # Test with alternative assay name
+    airway_fe <- estimateFactors(airway, nc = 2, assay_name = "normalised")
 
     expect_equal(dim(airway_fe), c("Features" = 18870, "Samples" = 8, "Components" = 2))
     expect_equal(reduced(airway_fe)[1, ], c("factor_1" = 0.0562, "factor_2" = -1.2809), tolerance = 1e-3)
@@ -30,9 +31,10 @@ test_that("Stability", {
 
     set.seed(2)
     airway <- .getAirwayData(n_features = 500)
+    assayNames(airway) <- c("counts", "normalised")  # Test with alternative assay name
 
-    stability_res <- estimateStability(airway, n_runs = 5, min_components = 2, max_components = 4, by = 1, mean_stability_threshold = 0.9)
-    stability_res_bootstrap <- estimateStability(airway, n_runs = 5, min_components = 2, max_components = 4, by = 1, mean_stability_threshold = 0.9, resample = TRUE)
+    stability_res <- estimateStability(airway, n_runs = 5, min_components = 2, max_components = 4, by = 1, mean_stability_threshold = 0.9, assay_name = "normalised")
+    stability_res_bootstrap <- estimateStability(airway, n_runs = 5, min_components = 2, max_components = 4, by = 1, mean_stability_threshold = 0.9, resample = TRUE, assay_name = "normalised")
 
     expect_equal(stability_res$selected_nc, 4)
     expect_equal(stability_res_bootstrap$selected_nc, NULL)
@@ -42,14 +44,14 @@ test_that("Stability", {
 
     plotStability(stability_res)
 
-    airway_fe <- estimateFactors(airway, nc = 2, use_stability = TRUE, n_runs = 5, BPPARAM = BiocParallel::SerialParam(RNGseed = 1))
+    airway_fe <- estimateFactors(airway, nc = 2, use_stability = TRUE, n_runs = 5, BPPARAM = BiocParallel::SerialParam(RNGseed = 1), assay_name = "normalised")
 
     expect_equal(reduced(airway_fe)[1, ], c("factor_1" = -1.11680, "factor_2" = 0.00221), tolerance = 1e-3)
     expect_equal(loadings(airway_fe)[1, ], c("factor_1" = -0.0196, "factor_2" = -0.6465), tolerance = 1e-3)
     expect_equal(names(stability(airway_fe)), componentNames(airway_fe))
     expect_true(all(stability(airway_fe) > 0.99))
 
-    airway_fe_bootstrap <- estimateFactors(airway, nc = 2, use_stability = TRUE, n_runs = 5, resample = TRUE, BPPARAM = BiocParallel::SerialParam(RNGseed = 1))
+    airway_fe_bootstrap <- estimateFactors(airway, nc = 2, use_stability = TRUE, n_runs = 5, resample = TRUE, BPPARAM = BiocParallel::SerialParam(RNGseed = 1), assay_name = "normalised")
 
     expect_equal(reduced(airway_fe_bootstrap)[1, ], c("factor_1" = -0.6462, "factor_2" = -1.2427), tolerance = 1e-2)
     expect_equal(loadings(airway_fe_bootstrap)[1, ], c("factor_1" = -0.6539, "factor_2" = -0.0837), tolerance = 1e-2)

--- a/tests/testthat/test_modules.R
+++ b/tests/testthat/test_modules.R
@@ -3,12 +3,13 @@ context("modules")
 test_that("Identify modules", {
     set.seed(2)
     airway <- .getAirwayData(n_features = 500)
+    assayNames(airway) <- c("counts", "normalised")  # Test with alternative assay name
 
     WGCNA::disableWGCNAThreads()
-    fit_indices <- assessSoftThreshold(airway)
+    fit_indices <- assessSoftThreshold(airway, assay_name = "normalised")
     estimated_power <- fit_indices$Power[fit_indices$estimated_power]
 
-    airway_me <- identifyModules(airway, verbose = 0, power = 21)
+    airway_me <- identifyModules(airway, verbose = 0, power = 21, assay_name = "normalised")
 
     expect_equal(dim(airway_me), c("Features" = 500, "Samples" = 8, "Components" = 6))
     expect_equal(componentNames(airway_me), paste0("module_", 0:5))


### PR DESCRIPTION
 * Fix estimateStability's handling of non-standard assay names
 * Update tests to check that non-standard assay names are compatible with relevant methods